### PR TITLE
Fix loading assemblies when they're not in GAC

### DIFF
--- a/MainForm.ps1
+++ b/MainForm.ps1
@@ -1,17 +1,19 @@
+# return the directory of source files
+$Script:pathPanel= split-path -parent $MyInvocation.MyCommand.Definition
+
 #########################################################################
 #                        Add shared_assemblies                          #
 #########################################################################
 
+[System.Reflection.Assembly]::LoadWithPartialName('presentationframework')
+
 # Mahapps Library
-[System.Reflection.Assembly]::LoadFrom('Assembly\MahApps.Metro.dll')       | out-null
-[System.Reflection.Assembly]::LoadFrom('Assembly\System.Windows.Interactivity.dll') | out-null
+[System.Reflection.Assembly]::LoadFrom($pathPanel+'\Assembly\MahApps.Metro.dll')       | out-null
+[System.Reflection.Assembly]::LoadFrom($pathPanel+'\Assembly\System.Windows.Interactivity.dll') | out-null
 
 #########################################################################
 #                        Load Main Panel                                #
 #########################################################################
-
-# return the directory of source files
-$Script:pathPanel= split-path -parent $MyInvocation.MyCommand.Definition
 
 # function to load the xaml
 function LoadXaml ($filename){


### PR DESCRIPTION
Running won't work for network paths (UNC path, mapped drive) - see loadFromRemoteSources

Fix error messages
```
Exception lors de l'appel de «LoadFrom» avec «1» argument(s): «Impossible de charger le
fichier ou l'assembly 'file:///C:\WINDOWS\system32\Assembly\MahApps.Metro.dll' ou une de
ses dépendances. Le fichier spécifié est introuvable.»
Au caractère
C:\EXTRACT\PowershellGUI-theme-master\PowershellGUI-theme-master\MainForm.ps1:6 : 1
+ [System.Reflection.Assembly]::LoadFrom('Assembly\MahApps.Metro.dll')  ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : FileNotFoundException

Exception lors de l'appel de «LoadFrom» avec «1» argument(s): «Impossible de charger le
fichier ou l'assembly
'file:///C:\WINDOWS\system32\Assembly\System.Windows.Interactivity.dll' ou une de ses
dépendances. Le fichier spécifié est introuvable.»
Au caractère
C:\EXTRACT\PowershellGUI-theme-master\PowershellGUI-theme-master\MainForm.ps1:7 : 1
+ [System.Reflection.Assembly]::LoadFrom('Assembly\System.Windows.Inter ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : FileNotFoundException

Type [Windows.Markup.XamlReader] introuvable.
```